### PR TITLE
Improve Extendability

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,66 @@ Learn more about using the SDK in the full [API Reference](./docs)
 In the detailed documents, you may see some of the methods have an <img src="docs/experimental-badge.svg" alt="experimental-badge" /> badge. These methods are based on experimental APIs. Experimental APIs provide early access to APIs that are currently under development. The documentation may highlight new features, new data properties and data models, new filters, and other features specific to the new API. Our intention in providing you with early access to the documentation for these APIs in the experimental stage is that you may plan for implementing them in the near future and provide us with necessary feedback to meet your needs. These APIs are most often NOT operational and the documentation is subject to change frequently from the time the documentation is available to the time the APIs are fully released. Experimental APIs will generally require testing and development on your own applications before relying on them in your stable production environments
 
 
+## Extendability
+
+You may want to test out released <img src="docs/experimental-badge.svg" alt="experimental-badge" /> APIs that are not yet availbale in the SDK or want to add more functionality to the `CmpClient` class based on your usecase. You can write your own custom class extending from the `CmpClient` class provided by the SDK. Here is an example of how you can write your own custom class extending from the `CmpClient` class.
+
+
+```TypeScript
+import { CmpClient } from "@welcomesoftware/cmp-sdk";
+import { APICaller } from '@welcomesoftware/cmp-sdk/lib/modules/api-caller';
+import type { CmpClientConstructorParam } from "@welcomesoftware/cmp-sdk";
+
+// define your own module
+class StructuredContent {
+  #apiCaller: APICaller;
+
+  constructor(apiCaller: APICaller) {
+    this.#apiCaller = apiCaller;
+  }
+
+  async acknowledgeContentReviewRequest(
+    url: string,
+    contentHash: string,
+    userId: string,
+  ) {
+    const payload: ContentPreviewRequestedAcknowledgePayload = {
+      acknowledgedBy: userId,
+      contentHash: contentHash,
+    };
+    await this.#apiCaller.post(url, payload);
+  }
+
+  async completeContentReviewRequest(
+    url: string,
+    sitename: string,
+    previewUrl: string,
+  ) {
+    const payload = {
+      keyed_previews: {
+        [sitename]: previewUrl,
+      },
+    };
+
+    await this.#apiCaller.post(url, payload);
+  }
+}
+
+// extend CmpClient
+class ExtendedCmpClient extends CmpClient {
+  structuredContent: StructuredContent;
+
+  constructor(params: CmpClientConstructorParam) {
+    super(params);
+    const apiCaller = new APICaller(this.auth, params.enableAutoRetry, false);
+    this.structuredContent = new StructuredContent(apiCaller);
+  }
+}
+
+// initiate an instance of the `ExtendedCmpClient` class instead of the `CmpClient` class
+export const cmpClient = new ExtendedCmpClient(...)
+```
+
 ## Example App
 
 See the [Example](./Example/) folder for a full demo.

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -2,6 +2,7 @@
 
 The initialized object has the following modules and each module has their own methods.
 * [Auth](./auth.md)
+* [ApiCaller](./apiCaller.md)
 * [Campaign](./campaign.md)
 * [Label](./label.md)
 * [Library](./library.md)

--- a/docs/modules/apiCaller.md
+++ b/docs/modules/apiCaller.md
@@ -1,0 +1,79 @@
+# ApiCaller
+
+The `ApiCaller` module is useful if you want to extend the `CmpClient` class with your own custom modules. `ApiCaller` module takes care of making the network call to _Welcome_ Open API server with the access token.
+
+You can import the `ApiCaller` class from `"@welcomesoftware/cmp-sdk/lib/modules/api-caller"`.
+
+The constructor of the `ApiCaller` class takes three parameters. First one is the instance of the `Auth` module. The second parameter is a boolean value. If its set to `true` then when an API call gets 401 status code in the response, it will try to refresh the access token with the current refresh token and try the request again. If the second call also gets the same response, it will raise Unauthorized [Error](../errors/README.md).
+
+The third parameter is also a boolean value which is set to `true` as default value. _Welcome_ API server expects payload object keys in snake case and sends response object with snake case keys. In JavaScript, the usual convention is to use camel case. If the third parameter is `true`, `ApiCaller` module converts payload object keys to snake case and response object keys to camel case. If its `false`, the ApiCaller module does not do any conversion.
+
+```javascript
+import { CmpClient } from "@welcomesoftware/cmp-sdk";
+import { APICaller } from '@welcomesoftware/cmp-sdk/lib/modules/api-caller';
+
+class ExtendedCmpClient extends CmpClient {
+  constructor(params) {
+    super(params)
+    const apiCaller = new APICaller(this.auth, params.enableAutoRetry, false);
+    ...
+  }
+}
+```
+
+The module provides the following methods.
+
+## `get`
+
+**_parameters:_**
+
+- endpoint: string
+- tokenGetParam: any (optional)
+
+**_returns:_** Promise< object >
+
+the `endpont` can be relative endpoint or full url.
+
+## `post`
+
+**_parameters:_**
+
+- endpoint: string
+- payload: any (object)
+- tokenGetParam: any (optional)
+
+**_returns:_** Promise< object >
+
+the `endpont` can be relative endpoint or full url.
+
+
+## `patch`
+
+- endpoint: string
+- payload: any (object)
+- tokenGetParam: any (optional)
+
+**_returns:_** Promise< object >
+
+the `endpont` can be relative endpoint or full url.
+
+
+## `put`
+
+- endpoint: string
+- payload: any (object)
+- tokenGetParam: any (optional)
+
+**_returns:_** Promise< object >
+
+the `endpont` can be relative endpoint or full url.
+
+
+## `delete`
+
+- endpoint: string
+- tokenGetParam: any (optional)
+
+**_returns:_** Promise< null >
+
+the `endpont` can be relative endpoint or full url.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { CmpClient } from "./welcome";
-export { CmpClient as WelcomeClient } from "./welcome"
+export { CmpClient as WelcomeClient } from "./welcome";
+export type { CmpClientConstructorParam } from "./welcome";

--- a/src/modules/api-caller/api-caller.ts
+++ b/src/modules/api-caller/api-caller.ts
@@ -16,13 +16,15 @@ import {
 export class APICaller {
   #shouldRetry: boolean;
   #auth: Auth;
+  #shouldConvertObjectKeyCase: boolean;
 
   #host = "https://api.welcomesoftware.com";
   #apiVersion = "v3";
 
-  constructor(auth: Auth, enableAutoRetry: boolean) {
+  constructor(auth: Auth, enableAutoRetry: boolean, shouldConvertObjectKeyCase: boolean = true) {
     this.#auth = auth;
     this.#shouldRetry = enableAutoRetry;
+    this.#shouldConvertObjectKeyCase = shouldConvertObjectKeyCase;
   }
 
   #formError(body: ErrorResponseBody, code?: number) {
@@ -58,7 +60,9 @@ export class APICaller {
       url = new URL(this.#host + "/" + this.#apiVersion + endpoint);
     }
     const payloadStringified = JSON.stringify(
-      convertObjectKeysToSnakeCase(payload)
+      this.#shouldConvertObjectKeyCase
+        ? convertObjectKeysToSnakeCase(payload)
+        : payload
     );
     const options: RequestOptions = {
       host: url.host,
@@ -94,7 +98,9 @@ export class APICaller {
             responseBody = JSON.parse(data);
           }
 
-          responseBody = convertObjectKeysToCamelCase(responseBody);
+          responseBody = this.#shouldConvertObjectKeyCase
+            ? convertObjectKeysToCamelCase(responseBody)
+            : responseBody;
           if (statusCode && statusCode < 299) {
             resolve(responseBody);
             return;

--- a/src/welcome.ts
+++ b/src/welcome.ts
@@ -8,7 +8,7 @@ import { Uploader } from "./modules/uploader";
 import { Task } from "./modules/task";
 import { Publishing } from "./modules/publishing";
 
-interface CmpClientConstructorParam {
+export interface CmpClientConstructorParam {
   accessToken: string | ((tokenGetParam?: any) => string | Promise<string>);
   refreshToken: string | ((tokenGetParam?: any) => string | Promise<string>);
   clientId?: string;


### PR DESCRIPTION
This PR improves extendability of the `CmpClient` class by 

- exporting `CmpClientConstructorParam` interface
- adding `shouldConvertObjectKeyCase` parameter to the constructor of `ApiCaller` class
- adding documentation for the `ApiCaller` class
- adding `Extendability` section on the `README.md` file
